### PR TITLE
fix SSL handshake issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.6
+
+- bugfix: gevent.monkey causes https requests to fail under certain
+circumstances while doing SSL handshake
+
 ## 0.0.5
 
 - uses server API v1.1.1

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Bets API client
 Installation
 ============
 
-    pip install bets-api==0.0.5
+    pip install bets-api==0.0.6
 
 Basic Usage
 ===========

--- a/bets/__init__.py
+++ b/bets/__init__.py
@@ -1,6 +1,9 @@
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
-from gevent import monkey; monkey.patch_socket()
+from gevent import monkey
+monkey.patch_socket()
+monkey.patch_ssl()
+monkey.patch_time()
 
 import re
 import json


### PR DESCRIPTION
The problem is that if any request library (for instance, `xmlrpclib`) gets imported earlier than `gevent.monkey.patch_socket` is called, then any https request fails during SSL handshake.

References:
- https://github.com/kennethreitz/requests/issues/1480#issuecomment-22604424
- https://github.com/swiftstack/ssbench/issues/69#issuecomment-17556190
